### PR TITLE
Be able to run test suite with CoffeeScript 1.7+

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,3 @@
 --reporter spec
 --require test/setup
---compilers coffee:coffee-script
+--compilers coffee:coffee-script/register


### PR DESCRIPTION
Having a dev dependency `"coffee-script": ">= 1.4.0"` in `package.json` installs latest CoffeeScript (version 1.7.1) and running the test suite using `mocha` currently fails.

The reason is that starting with CoffeeScript 1.7.0 (released on 2014-01-28, see [changelog](http://coffeescript.org/#changelog)), registration of the CoffeeScript compiler in Node is done explicitly and by using `coffee-script/register` instead of just `coffee-script`.

The file `test/mocha.opts` has been updated accordingly.
